### PR TITLE
#02-route-that-list-artist-albums

### DIFF
--- a/src/app/api/endpoints/handlers/dtos/response/album_response.go
+++ b/src/app/api/endpoints/handlers/dtos/response/album_response.go
@@ -2,20 +2,18 @@ package response
 
 import (
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type AlbumDTO struct {
-	ID          uuid.UUID `json:"id"`
+	ID          string    `json:"id"`
 	Name        string    `json:"name"`
-	ArtistID    uuid.UUID `json:"artistId"`
+	ArtistID    string    `json:"artistId"`
 	ReleaseDate time.Time `json:"release_date"`
 	Description *string   `json:"description,omitempty"`
 	ImageURL    *string   `json:"image_url,omitempty"`
 }
 
-func NewAlbumDTO(id uuid.UUID, name string, artistID uuid.UUID, releaseDate time.Time, description *string, imageURL *string) *AlbumDTO {
+func NewAlbumDTO(id string, name string, artistID string, releaseDate time.Time, description *string, imageURL *string) *AlbumDTO {
 	return &AlbumDTO{
 		ID:          id,
 		Name:        name,

--- a/src/app/api/endpoints/handlers/user_handlers.go
+++ b/src/app/api/endpoints/handlers/user_handlers.go
@@ -4,7 +4,6 @@ import (
 	"echofy_backend/src/app/api/endpoints/handlers/dtos/response"
 	"echofy_backend/src/core/interfaces/primary"
 	"net/http"
-	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -171,7 +170,7 @@ func (h UserHandlers) GetAlbumsArtist(context echo.Context) error {
 			each.ID(),
 			each.Name(),
 			each.ArtistID(),
-			time.Time{},
+			each.ReleaseDate(),
 			each.Description(),
 			nil,
 		)

--- a/src/app/api/endpoints/handlers/user_handlers.go
+++ b/src/app/api/endpoints/handlers/user_handlers.go
@@ -4,6 +4,7 @@ import (
 	"echofy_backend/src/app/api/endpoints/handlers/dtos/response"
 	"echofy_backend/src/core/interfaces/primary"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
@@ -140,6 +141,46 @@ func (h UserHandlers) GetAlbumTracks(context echo.Context) error {
 	}
 
 	return context.JSON(http.StatusOK, songs)
+}
+
+// GetAlbumByArtistID
+// @ID GetAlbumByArtistID
+// @Summary Buscar todas os álbuns de um artista pelo seu ID
+// @Tags Rotas do usuário
+// @Description Rota que permite que se busque todos os álbuns de um determinado artista
+// @Param artistID path string true "ID do Artista." default(5K4W6rqBFWDnAN6FQUkS6x)
+// @Produce json
+// @Success 200 {array} response.AlbumDTO "Requisição realizada com sucesso."
+// @Failure 401 {object} response.ErrorMessage "Usuário não autorizado."
+// @Failure 403 {object} response.ErrorMessage "Acesso negado."
+// @Failure 422 {object} response.ErrorMessage "Algum dado informado não pôde ser processado."
+// @Failure 500 {object} response.ErrorMessage "Ocorreu um erro inesperado."
+// @Failure 503 {object} response.ErrorMessage "A base de dados não está disponível."
+// @Router /user/album/{artistID}/albums [get]
+func (h UserHandlers) GetAlbumsArtist(context echo.Context) error {
+	artistID := context.Param(artistID)
+
+	albumsRows, fetchErr := h.service.FetchArtistAlbumsByID(artistID)
+	if fetchErr != nil {
+		return getHttpHandledErrorResponse(context, fetchErr)
+	}
+
+	albums := make([]response.AlbumDTO, 0)
+	for _, each := range albumsRows {
+		albumBuilder := response.NewAlbumDTO(
+			each.ID(),
+			each.Name(),
+			each.ArtistID(),
+			time.Time{},
+			each.Description(),
+			nil,
+		)
+		albums = append(albums, *albumBuilder)
+
+	}
+
+	return context.JSON(http.StatusOK, albums)
+
 }
 
 // GetUserBasicInfo

--- a/src/app/api/endpoints/handlers/user_handlers.go
+++ b/src/app/api/endpoints/handlers/user_handlers.go
@@ -155,8 +155,8 @@ func (h UserHandlers) GetAlbumTracks(context echo.Context) error {
 // @Failure 422 {object} response.ErrorMessage "Algum dado informado não pôde ser processado."
 // @Failure 500 {object} response.ErrorMessage "Ocorreu um erro inesperado."
 // @Failure 503 {object} response.ErrorMessage "A base de dados não está disponível."
-// @Router /user/album/{artistID}/albums [get]
-func (h UserHandlers) GetAlbumsArtist(context echo.Context) error {
+// @Router /user/artist/{artistID}/albums [get]
+func (h UserHandlers) GetArtistAlbums(context echo.Context) error {
 	artistID := context.Param(artistID)
 
 	albumsRows, fetchErr := h.service.FetchArtistAlbumsByID(artistID)

--- a/src/app/api/endpoints/handlers/user_handlers.go
+++ b/src/app/api/endpoints/handlers/user_handlers.go
@@ -172,7 +172,7 @@ func (h UserHandlers) GetAlbumsArtist(context echo.Context) error {
 			each.ArtistID(),
 			each.ReleaseDate(),
 			each.Description(),
-			nil,
+			each.ImageURL(),
 		)
 		albums = append(albums, *albumBuilder)
 

--- a/src/app/api/endpoints/routes/user/user_routes.go
+++ b/src/app/api/endpoints/routes/user/user_routes.go
@@ -16,4 +16,5 @@ func LoadUserRoutes(group *echo.Group) {
 	userGroup.GET("/playlist/:playlistID", userHandlers.GetPlaylistByID)
 	userGroup.GET("/playlist/:playlistID/songs", userHandlers.GetSongsByPlaylistID)
 	userGroup.GET("/album/:albumID/songs", userHandlers.GetAlbumTracks)
+	userGroup.GET("/album/:artistID/albums", userHandlers.GetAlbumsArtist)
 }

--- a/src/app/api/endpoints/routes/user/user_routes.go
+++ b/src/app/api/endpoints/routes/user/user_routes.go
@@ -16,5 +16,5 @@ func LoadUserRoutes(group *echo.Group) {
 	userGroup.GET("/playlist/:playlistID", userHandlers.GetPlaylistByID)
 	userGroup.GET("/playlist/:playlistID/songs", userHandlers.GetSongsByPlaylistID)
 	userGroup.GET("/album/:albumID/songs", userHandlers.GetAlbumTracks)
-	userGroup.GET("/album/:artistID/albums", userHandlers.GetAlbumsArtist)
+	userGroup.GET("/artist/:artistID/albums", userHandlers.GetArtistAlbums)
 }

--- a/src/app/api/utils/utils.go
+++ b/src/app/api/utils/utils.go
@@ -1,11 +1,11 @@
 package utils
 
 import (
+	"echofy_backend/src/core"
+	"echofy_backend/src/core/domain/user"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"echofy_backend/src/core"
-	"echofy_backend/src/core/domain/user"
 	"os"
 	"strings"
 

--- a/src/core/domain/album/album.go
+++ b/src/core/domain/album/album.go
@@ -33,6 +33,6 @@ func (a Album) Description() *string {
 	return a.description
 }
 
-func (a Album) ImageURL() string {
-	return a.imageURL
+func (a Album) ImageURL() *string {
+	return &a.imageURL
 }

--- a/src/core/domain/album/album.go
+++ b/src/core/domain/album/album.go
@@ -2,20 +2,18 @@ package album
 
 import (
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type Album struct {
-	id          uuid.UUID
+	id          string
 	name        string
-	artistID    uuid.UUID
+	artistID    string
 	releaseDate time.Time
 	description *string
 	imageURL    string
 }
 
-func (a Album) ID() uuid.UUID {
+func (a Album) ID() string {
 	return a.id
 }
 
@@ -23,7 +21,7 @@ func (a Album) Name() string {
 	return a.name
 }
 
-func (a Album) ArtistID() uuid.UUID {
+func (a Album) ArtistID() string {
 	return a.artistID
 }
 

--- a/src/core/domain/album/builder.go
+++ b/src/core/domain/album/builder.go
@@ -5,8 +5,6 @@ import (
 	"echofy_backend/src/core/errors"
 	"echofy_backend/src/core/messages"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 type Builder struct {
@@ -14,8 +12,8 @@ type Builder struct {
 	invalidFields []errors.InvalidField
 }
 
-func (b *Builder) WithID(id uuid.UUID) *Builder {
-	if id == uuid.Nil {
+func (b *Builder) WithID(id string) *Builder {
+	if id == "" {
 		b.invalidFields = append(b.invalidFields, errors.InvalidField{
 			Name:        messages.AlbumID,
 			Description: messages.AlbumIDInvalidErrMsg,
@@ -36,8 +34,8 @@ func (b *Builder) WithName(name string) *Builder {
 	return b
 }
 
-func (b *Builder) WithArtistID(artistID uuid.UUID) *Builder {
-	if artistID == uuid.Nil {
+func (b *Builder) WithArtistID(artistID string) *Builder {
+	if artistID == "" {
 		b.invalidFields = append(b.invalidFields, errors.InvalidField{
 			Name:        messages.AlbumArtistID,
 			Description: messages.AlbumArtistIDInvalidErrMsg,

--- a/src/core/interfaces/primary/user_manager.go
+++ b/src/core/interfaces/primary/user_manager.go
@@ -1,6 +1,7 @@
 package primary
 
 import (
+	"echofy_backend/src/core/domain/album"
 	"echofy_backend/src/core/domain/playlist"
 	"echofy_backend/src/core/domain/song"
 	"echofy_backend/src/core/domain/user"
@@ -12,4 +13,5 @@ type UserManager interface {
 	FetchPlaylistByID(playlistID string) (*playlist.Playlist, errors.Error)
 	FetchSongsByAlbumID(albumID string) ([]song.Song, errors.Error)
 	FetchUserBasicInfo() (*user.User, errors.Error)
+	FetchArtistAlbumsByID(artistID string) ([]album.Album, errors.Error)
 }

--- a/src/core/interfaces/repository/user_loader.go
+++ b/src/core/interfaces/repository/user_loader.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"echofy_backend/src/core/domain/album"
 	"echofy_backend/src/core/domain/playlist"
 	"echofy_backend/src/core/domain/song"
 	"echofy_backend/src/core/domain/user"
@@ -12,4 +13,5 @@ type UserLoader interface {
 	FindPlaylistByID(playlistID string) (*playlist.Playlist, errors.Error)
 	FindSongsByAlbumID(albumID string) ([]song.Song, errors.Error)
 	FindUserBasicInfo() (*user.User, errors.Error)
+	FindArtistAlbumsByID(artistID string) ([]album.Album, errors.Error)
 }

--- a/src/core/services/user_services.go
+++ b/src/core/services/user_services.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"echofy_backend/src/core/domain/album"
 	"echofy_backend/src/core/domain/playlist"
 	"echofy_backend/src/core/domain/song"
 	"echofy_backend/src/core/domain/user"
@@ -50,6 +51,15 @@ func (u UserServices) FetchUserBasicInfo() (*user.User, errors.Error) {
 	}
 
 	return user, nil
+}
+
+func (u UserServices) FetchArtistAlbumsByID(artistID string) ([]album.Album, errors.Error) {
+	albumInstance, err := u.userRepository.FindArtistAlbumsByID(artistID)
+	if err != nil {
+		return nil, err
+	}
+
+	return albumInstance, nil
 }
 
 func NewUserServices(userRepository repository.UserLoader, logger logger.Logger) *UserServices {

--- a/src/infra/spotify/user_spotify_repository.go
+++ b/src/infra/spotify/user_spotify_repository.go
@@ -186,18 +186,16 @@ func (u UserSpotifyRepository) FindArtistAlbumsByID(artistID string) ([]album.Al
 	}
 
 	albums := make([]album.Album, 0)
-	for _, single_album := range artist.Albums {
-		albumID := single_album.ID
-		albumName := single_album.Name
+	for _, singleAlbum := range artist.Albums {
+		albumID := singleAlbum.ID
+		albumName := singleAlbum.Name
 
-		albumRealeaseDate, err := time.Parse("2006-01-02", single_album.ReleaseDate)
+		albumRealeaseDate, err := time.Parse("2006-01-02", singleAlbum.ReleaseDate)
 		if err != nil {
 			return nil, errors.NewUnexpectedError(messages.UnexpectedErrorMessage, err)
 		}
 
-		var albumImage *string
-
-		albumImage = &single_album.Images[0].URL
+		albumImage := &singleAlbum.Images[0].URL
 
 		albumBuilder := album.NewBuilder()
 		albumBuilder.WithArtistID(artistID).WithID(albumID.String()).WithName(albumName).WithReleaseDate(albumRealeaseDate).WithImageURL(*albumImage)

--- a/src/infra/spotify/user_spotify_repository.go
+++ b/src/infra/spotify/user_spotify_repository.go
@@ -195,8 +195,12 @@ func (u UserSpotifyRepository) FindArtistAlbumsByID(artistID string) ([]album.Al
 			return nil, errors.NewUnexpectedError(messages.UnexpectedErrorMessage, err)
 		}
 
+		var albumImage *string
+
+		albumImage = &single_album.Images[0].URL
+
 		albumBuilder := album.NewBuilder()
-		albumBuilder.WithArtistID(artistID).WithID(albumID.String()).WithName(albumName).WithReleaseDate(albumRealeaseDate)
+		albumBuilder.WithArtistID(artistID).WithID(albumID.String()).WithName(albumName).WithReleaseDate(albumRealeaseDate).WithImageURL(*albumImage)
 		albumBuilded, createdError := albumBuilder.Build()
 		if createdError != nil {
 			return nil, errors.NewUnexpectedError(messages.UnexpectedErrorMessage, createdError)

--- a/src/infra/spotify/user_spotify_repository.go
+++ b/src/infra/spotify/user_spotify_repository.go
@@ -10,6 +10,7 @@ import (
 	"echofy_backend/src/core/errors"
 	"echofy_backend/src/core/interfaces/repository"
 	"echofy_backend/src/core/messages"
+	"time"
 
 	"github.com/zmb3/spotify/v2"
 	spotifyauth "github.com/zmb3/spotify/v2/auth"
@@ -189,17 +190,24 @@ func (u UserSpotifyRepository) FindArtistAlbumsByID(artistID string) ([]album.Al
 		albumID := single_album.ID
 		albumName := single_album.Name
 
+		albumRealeaseDate, err := time.Parse("2006-01-02", single_album.ReleaseDate)
+		if err != nil {
+			return nil, errors.NewUnexpectedError(messages.UnexpectedErrorMessage, err)
+		}
+
 		albumBuilder := album.NewBuilder()
-		albumBuilder.WithArtistID(artistID).WithID(albumID.String()).WithName(albumName)
+		albumBuilder.WithArtistID(artistID).WithID(albumID.String()).WithName(albumName).WithReleaseDate(albumRealeaseDate)
 		albumBuilded, createdError := albumBuilder.Build()
 		if createdError != nil {
 			return nil, errors.NewUnexpectedError(messages.UnexpectedErrorMessage, createdError)
 		}
 
 		albums = append(albums, *albumBuilded)
+
 	}
 
 	return albums, nil
+
 }
 
 func NewUserSpotifyRepository() *UserSpotifyRepository {


### PR DESCRIPTION
# O que foi feito ? 

Foram criadas as camadas `handlers`, `service` e `repository` da logica  de conseguir pegar os álbuns de um determinado artista

# Alterações importantes: 

* Mudança na `domain` de artista e de album para os respectivos ID's virarem em string e a função `imageURL`  de album retorna o ponteiro da string
* O campo `RealeaseDate` de album, vem como um string, para converter ele para o tipo `time.Time` eu utilizei a função `Parse`
![image](https://github.com/user-attachments/assets/9e251965-3a07-4cd6-a848-14709ea434d9)

Closes #2 